### PR TITLE
testing structure, and cmake structure updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,22 @@ project(splx)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_BUILD_TYPE Debug)
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/qpOASES)
-set(QPOASES_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/third_party/qpOASES/include)
 
 find_package(Eigen3 REQUIRED)
 
+add_library(splx INTERFACE)
+target_link_libraries(splx INTERFACE)
+target_include_directories(
+  splx INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${EIGEN3_INCLUDE_DIR}
+ )
+
+
+# add tests if SPLX_BUILD_TESTING is ON and BUILD_TESTING os ON
+option(SPLX_BUILD_TESTING "build tests" OFF)
 include(CTest)
-if (BUILD_TESTING)
+if(BUILD_TESTING AND SPLX_BUILD_TESTING)
       add_subdirectory(test)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,41 +1,97 @@
-include_directories(
-  ${PROJECT_SOURCE_DIR}/include
-  ${PROJECT_SOURCE_DIR}/third_party/Catch2/single_include/catch2
-  ${EIGEN3_INCLUDE_DIR}
-  ${QPOASES_INCLUDE_DIR}
+cmake_minimum_required(VERSION 3.1)
 
-)
+# if splx is not defined, stop cmaking.
+if(NOT TARGET splx)
+  message(FATAL_ERROR "splx not defined, do not cmake this file directly")
+endif()
 
+# add qpoases without tests
+set(QPOASES_BUILD_EXAMPLES CACHE BOOL OFF)
+add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/qpOASES qpOASES)
+set(QPOASES_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/third_party/qpOASES/include)
 
-add_executable(
-  beziertests
-  bezier_tests.cpp
+# add catch without tests
+set(CATCH_BUILD_TESTING CACHE BOOL OFF)
+add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/Catch2 Catch2)
+
+# compile main as a seperate library so that we can link it to other
+# tests fast
+add_library(
+  splx_catchmain
   main.cpp
 )
-
-add_executable(
-bsplinetests
-bspline_tests.cpp
-main.cpp
+target_link_libraries(
+  splx_catchmain PUBLIC
+  Catch2
 )
 
-
-add_executable(
-curvetests
-curve_tests.cpp
-main.cpp
+# these are the libraries that tests link to in general
+set(
+  TEST_LIBRARIES
+  splx_catchmain
+  splx
+  qpOASES
 )
 
-
+# tests for bezier.h
 add_executable(
-splinetests
-spline_tests.cpp
-main.cpp
+  splx_bezier_test
+  bezier_tests.cpp
 )
+target_link_libraries(
+  splx_bezier_test PRIVATE
+  ${TEST_LIBRARIES}
+)
+target_include_directories(
+  splx_bezier_test PRIVATE
+  ${QPOASES_INCLUDE_DIR}
+)
+add_test(NAME splx_bezier_test COMMAND splx_bezier_test)
 
 
+# tests for bspline.h
+add_executable(
+  splx_bspline_test
+  bspline_tests.cpp
+)
+target_link_libraries(
+  splx_bspline_test PRIVATE
+  ${TEST_LIBRARIES}
+)
+target_include_directories(
+  splx_bspline_test PRIVATE
+  ${QPOASES_INCLUDE_DIR}
+)
+add_test(NAME splx_bspline_test COMMAND splx_bspline_test)
 
-add_test(NAME BezierTests COMMAND $<TARGET_FILE:beziertests>)
-add_test(NAME BSplineTests COMMAND $<TARGET_FILE:bsplinetests>)
-add_test(NAME CurveTests COMMAND $<TARGET_FILE:curvetests>)
-add_test(NAME SplineTests COMMAND $<TARGET_FILE:splinetests>)
+
+# tests for curve.h
+add_executable(
+  splx_curve_test
+  curve_tests.cpp
+)
+target_link_libraries(
+  splx_curve_test PRIVATE
+  ${TEST_LIBRARIES}
+)
+target_include_directories(
+  splx_curve_test PRIVATE
+  ${QPOASES_INCLUDE_DIR}
+)
+add_test(NAME splx_curve_test COMMAND splx_curve_test)
+
+
+# tests for spline.h
+add_executable(
+  splx_spline_test
+  spline_tests.cpp
+)
+target_link_libraries(
+  splx_spline_test PRIVATE
+  ${TEST_LIBRARIES}
+)
+target_include_directories(
+  splx_spline_test PRIVATE
+  ${QPOASES_INCLUDE_DIR}
+)
+add_test(NAME splx_spline_test COMMAND splx_spline_test)

--- a/test/bezier_tests.cpp
+++ b/test/bezier_tests.cpp
@@ -1,8 +1,11 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
+#include "bezier.h"
 
-TEST_CASE( "example test" ) {
+TEST_CASE( "bezier test" ) {
 
-  REQUIRE(0==0);
+
+  splx::Bezier<double, 3U> bez(3);
+  REQUIRE(bez.m_a==3);
 
 
 }

--- a/test/bspline_tests.cpp
+++ b/test/bspline_tests.cpp
@@ -1,6 +1,7 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
+#include "bspline.h"
 
-TEST_CASE( "example test" ) {
+TEST_CASE( "bspline test" ) {
 
   REQUIRE(0==0);
 

--- a/test/curve_tests.cpp
+++ b/test/curve_tests.cpp
@@ -1,6 +1,7 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
+#include "curve.h"
 
-TEST_CASE( "example test" ) {
+TEST_CASE( "curve test" ) {
 
   REQUIRE(0==0);
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch.hpp"

--- a/test/spline_tests.cpp
+++ b/test/spline_tests.cpp
@@ -1,6 +1,7 @@
-#include "catch.hpp"
+#include "catch2/catch.hpp"
+#include "spline.h"
 
-TEST_CASE( "example test" ) {
+TEST_CASE( "spline test" ) {
 
   REQUIRE(0==0);
 


### PR DESCRIPTION
* I created a library for catch main, since compiling it for each test was taking time. Now it is faster than before.
* I made splx an interface library that people can directly link to instead of directly including `include` directory.
* I added SPLX_BUILD_TESTING option through which users of the library can enable/disable testing for splx only.(Previously it was only using BUILD_TESTING option, which is global for all submodules)
* Now, we include qpoases only in cmakelists of tests, since qpoases is not used in the library.
* Removed  set(CMAKE_BUILD_TYPE Debug). People can set this by hand if they want to.
* Testing for qpOASES and Catch2 is disabled by default. Users can make them ON if they want to.